### PR TITLE
style: beautify GitHub profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,39 @@
-## Hi there 👋
+<img src="https://capsule-render.vercel.app/api?type=waving&color=0:ff0a54,100:9c1de7&height=200&section=header&text=AMRICH%20ASF%20FUCK&fontSize=60&fontColor=fff&animation=fadeIn&fontAlignY=40"/>
 
-<!--
-**AMRICHASFUCK/AMRICHASFUCK** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
+<h2 align="center">Hi, I'm AMRICH 👋</h2>
 
-Here are some ideas to get you started:
+<p align="center">
+  <img src="https://komarev.com/ghpvc/?username=AMRICHASFUCK&style=flat-square&color=ff69b4"/>
+</p>
 
-- 🔭 I’m currently working on ...
-- 🌱 I’m currently learning ...
-- 👯 I’m looking to collaborate on ...
-- 🤔 I’m looking for help with ...
-- 💬 Ask me about ...
-- 📫 How to reach me: ...
-- 😄 Pronouns: ...
-- ⚡ Fun fact: ...
--->
+---
+
+### 🛠 Languages & Tools
+
+<p align="center">
+  <img src="https://skillicons.dev/icons?i=python,js,html,css,docker,linux,git"/>
+</p>
+
+### 💻 About Me
+- 🔥 Passionate about building modern web and mobile applications.
+- 🌱 Currently learning cloud infrastructure and clean architecture.
+- 💬 Ask me about automation, open source, or game design.
+- ⚡ Fun fact: I enjoy customizing README files to make profiles shine.
+
+### 📊 Stats
+<p align="center">
+  <img src="https://github-readme-stats.vercel.app/api?username=AMRICHASFUCK&show_icons=true&theme=tokyonight&count_private=true&hide_border=true" height="170"/>
+  <img src="https://github-readme-streak-stats.herokuapp.com?user=AMRICHASFUCK&theme=tokyonight&hide_border=true" height="170"/>
+</p>
+
+<p align="center">
+  <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=AMRICHASFUCK&layout=compact&theme=tokyonight&hide_border=true"/>
+</p>
+
+### 🤝 Connect
+<p align="center">
+  <a href="https://twitter.com/yourusername"><img src="https://img.shields.io/twitter/follow/yourusername?style=social"/></a>
+  <a href="https://www.linkedin.com/in/yourusername/"><img src="https://img.shields.io/badge/-LinkedIn-blue?style=flat&logo=Linkedin&logoColor=white"/></a>
+</p>
+
+<img src="https://capsule-render.vercel.app/api?type=waving&color=0:9c1de7,100:ff0a54&height=120&section=footer"/>


### PR DESCRIPTION
## Summary
- add colorful waving header and footer plus visitor count for extra flair
- showcase languages and tools with icon set
- expand stats section with streak and top languages cards

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6899b1ff7d88832193e3212cf9a83e47